### PR TITLE
Update ubuntu runners to 'latest'

### DIFF
--- a/.github/workflows/daily-dci.yml
+++ b/.github/workflows/daily-dci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   weekly-query:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SHELL: /bin/bash
       NUM_DAYS: 7

--- a/.github/workflows/quay-query.yml
+++ b/.github/workflows/quay-query.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   quay-query:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SHELL: /bin/bash
       REPO_NAME_LEGACY: cnf-certification-test


### PR DESCRIPTION
Similar to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2927

But since this is just a script running repo, lets just use `latest`.