### PR TITLE
Add jira update slack message

### DIFF
--- a/.github/workflows/jira-team-update.yml
+++ b/.github/workflows/jira-team-update.yml
@@ -1,0 +1,59 @@
+name: Weekly Jira Team Update
+on:
+  schedule:
+    # weekly on Sundays
+    - cron: '0 0 * * 0'
+  # pull_request:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  weekly-query:
+    runs-on: ubuntu-latest
+    env:
+      SHELL: /bin/bash
+      USERS: 'bpalm@redhat.com speretz@redhat.com greyerof@redhat.com aabugosh@redhat.com bmandal@redhat.com deliedit@redhat.com jmontesi@redhat.com shmoran@redhat.com speretz@redhat.com mlin@redhat.com'
+      PROJECT_ID: 'CNF'
+    
+    steps:
+      - name: Install the JQ package
+        run: sudo apt-get install jq -y
+
+      - name: Clone the telco-bot repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Clone the jiracrawler repository
+      - name: Checkout jiracrawler
+        uses: actions/checkout@v4
+        with:
+          repository: 'sebrandon1/jiracrawler'
+          path: jiracrawler
+          ref: v0.0.1
+
+      - name: Build the jiracrawler project
+        run: make build
+        working-directory: jiracrawler
+
+      - name: Set the config file via the jiracrawler project
+        run: ./jiracrawler config set -t ${{ secrets.JIRA_PERSONAL_TOKEN }} -s ${{ secrets.JIRA_PERSONAL_EMAIL }}
+        working-directory: jiracrawler
+
+      - name: Run the jiracrawler project for our list of users and collect the JSON output
+        run: ./jiracrawler get assignedissues ${USERS} --projectID ${PROJECT_ID} -o json > ${GITHUB_WORKSPACE}/jira-output-raw.json
+        working-directory: jiracrawler
+
+      # This santiizes the raw JSON output from essentially the entire API response into a readable format
+      - name: Translate the JSON output into a sanitized format
+        run: ./scripts/sanitize-raw-jira-format.sh ${GITHUB_WORKSPACE}/jira-output-raw.json ${GITHUB_WORKSPACE}/jira-output.json
+
+      - name: Print the sanitized JSON output
+        run: cat ${GITHUB_WORKSPACE}/jira-output.json
+
+      - name: Run the script to send the sanitized JSON output to Slack
+        run: ./scripts/send-cnf-team-jira-update.sh ${{ secrets.JIRA_UPDATE_SLACK_WEBHOOK }} ${GITHUB_WORKSPACE}/jira-output.json

--- a/scripts/sanitize-raw-jira-format.sh
+++ b/scripts/sanitize-raw-jira-format.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Usage: ./sanitize-raw-jira-format.sh <input_json_file> <output_json_file>
+# Requires: jq
+
+set -e
+
+if [[ $# -ne 2 ]]; then
+	echo "Usage: $0 <input_json_file> <output_json_file>"
+	exit 1
+fi
+
+INPUT_FILE="$1"
+OUTPUT_FILE="$2"
+
+jq -r '[.[] | .issues[] 
+  | select(.fields.assignee != null) 
+  | select(.fields.status.name != "Closed")
+  | {
+      name: .fields.assignee.displayName, 
+      email: .fields.assignee.emailAddress,
+      issue: {
+          key: .key, 
+          summary: .fields.summary,
+          status: .fields.status.name, 
+          priority: .fields.priority.name,
+          created: .fields.created,
+          updated: .fields.updated, 
+          url: ("https://issues.redhat.com/browse/" + .key), 
+          fixVersion: (.fields.fixVersions[0].name // "none")
+      }
+  }] | group_by(.name) | map({user: .[0].name, email: .[0].email, issues: map(.issue)})' "$INPUT_FILE" >"$OUTPUT_FILE"

--- a/scripts/send-cnf-team-jira-update.sh
+++ b/scripts/send-cnf-team-jira-update.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Usage: ./send-cnf-team-jira-update.sh <slack_webhook_url> <json_file>
+# Requires: jq, curl
+
+set -e
+
+if [[ $# -lt 2 ]]; then
+	echo "Usage: $0 <slack_webhook_url> <json_file>"
+	exit 1
+fi
+
+SLACK_WEBHOOK_URL="$1"
+JSON_FILE="$2"
+
+# Build the Slack message content
+MESSAGE=$(jq -r '
+  def fixver_counts:
+    [ .[] | .issues[] | {fixVersion} ]
+    | group_by(.fixVersion)
+    | map({fixVersion: .[0].fixVersion, count: length});
+
+  def fixver_summary:
+    fixver_counts
+    | map("- " + (if .fixVersion == "none" then "No Fix Version" else .fixVersion end) + ": " + (.count | tostring) + " issues")
+    | join("\n");
+
+  ([ .[] |
+    (.user + " (" + ((.issues | length | tostring)) + " issues assigned):\n") +
+    (
+      if ((.issues // []) | type) != "array" or ((.issues // []) | length) == 0 then
+        "  - No issues"
+      else
+        (.issues | map(
+          .url + " (" + (if .fixVersion == "none" then "No Fix Version" else .fixVersion end) + ") - Status: " + .status + " - Last Updated: " + (.updated | split("T")[0])
+        ) | join("\n"))
+      end
+    )
+  ] | join("\n")) +
+  "\n\nTeam Issue Totals by Fix Version:\n" + fixver_summary
+' "$JSON_FILE")
+
+# Construct the Slack payload for Workflow webhooks (text only)
+payload=$(jq -n --arg text "$MESSAGE" '{text: $text}')
+
+# Send to Slack
+curl -s -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate weekly Jira team updates and adds supporting scripts to process and send data to Slack. The most important changes include the creation of the workflow file, a script to sanitize raw Jira JSON data, and a script to send formatted data to Slack.

### New Workflow for Weekly Jira Updates:
* [`.github/workflows/jira-team-update.yml`](diffhunk://#diff-84ffa71ac44da3768f4f417a66090c2331b63c737d93907c9da573982b70bf63R1-R59): Added a GitHub Actions workflow that runs weekly to query Jira for assigned issues, process the data, and send a summary to Slack. It includes steps to set up dependencies, run the `jiracrawler` tool, sanitize the output, and send the results.

### Supporting Scripts:
* [`scripts/sanitize-raw-jira-format.sh`](diffhunk://#diff-34d82616d7fd5c5397268547bbfc2dee57e54c4238bdaa6395689a35b287f031R1-R32): Added a script to process raw Jira JSON data into a sanitized format. It filters issues assigned to users, excludes closed issues, and groups them by user. The output includes details like issue key, summary, status, priority, and fix version.
* [`scripts/send-cnf-team-jira-update.sh`](diffhunk://#diff-15b6ea11b7663403bd4bd8d75c5ad689e86510d0579593995939828945616da8R1-R47): Added a script to format the sanitized Jira data into a Slack-compatible message and send it to a Slack webhook. It includes a summary of issues by user and totals grouped by fix version.